### PR TITLE
Fix peer deps

### DIFF
--- a/docs/guides/01-getting-started.md
+++ b/docs/guides/01-getting-started.md
@@ -9,6 +9,11 @@ yarn add slate-portive
 npm install --save slate-portive
 ```
 
+You'll also need these peer dependencies:
+```bash
+yarn add slate slate-react
+```
+
 ### Presets
 
 Presets are a great way to start with `slate-portive`. They are easy to setup and includes the features most people want like image resizing and the upload progress bar.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "version": "1.0.9",
   "license": "Copyright Portive and MeZine Inc. 2022",
   "engines": {
-    "yarn": "1.22.x"
+    "node": "^14.x || >=16.0.0",
+    "yarn": ">=1.22.0"
   },
   "devDependencies": {
     "@thesunny/assert-type": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "version": "1.0.9",
   "license": "Copyright Portive and MeZine Inc. 2022",
   "engines": {
-    "node": "14.x",
     "yarn": "1.22.x"
   },
   "devDependencies": {
@@ -33,6 +32,9 @@
     "jest": "^27",
     "next": "10.x",
     "prettier": "^2",
+    "slate": "^0.80.0",
+    "slate-history": "^0.66.0",
+    "slate-react": "^0.80.0",
     "react": "^17",
     "react-dom": "^17",
     "ts-jest": "^27",
@@ -44,7 +46,9 @@
   },
   "peerDependencies": {
     "react": "^17",
-    "react-dom": "^17"
+    "react-dom": "^17",
+    "slate": ">=0.66.1",
+    "slate-react": ">=0.74.2"
   },
   "dependencies": {
     "@portive/api-types": "^6.0.0",
@@ -57,9 +61,6 @@
     "eventemitter3": "^4.0.7",
     "nanoid": "^3.3.2",
     "p-defer": "^3.0",
-    "slate": "^0.80.0",
-    "slate-history": "^0.66.0",
-    "slate-react": "^0.80.0",
     "zustand": "^3.7.2"
   },
   "scripts": {


### PR DESCRIPTION
- more flexible `engines`
- added slate, slate-react peer deps (not sure which version min. we need, I've just put the same ones than plate)